### PR TITLE
스크립트가 적용되지 않는 문제

### DIFF
--- a/scripts/klas-helper.user.js
+++ b/scripts/klas-helper.user.js
@@ -25,7 +25,7 @@ function jsCache(filePath) {
 	// 메인 파일 삽입
 	// 업데이트 시 즉각적으로 업데이트를 반영하기 위해 이러한 방식을 사용함
 	const scriptElement = document.createElement('script');
-	scriptElement.src = jsCache('https://ljm.wo.tc/test/main.js');
+	scriptElement.src = jsCache('https://nbsp1221.github.io/klas-helper/scripts/main.js');
 	document.head.appendChild(scriptElement);
 
 	// window.onload 설정

--- a/scripts/klas-helper.user.js
+++ b/scripts/klas-helper.user.js
@@ -25,23 +25,18 @@ function jsCache(filePath) {
 	// 메인 파일 삽입
 	// 업데이트 시 즉각적으로 업데이트를 반영하기 위해 이러한 방식을 사용함
 	const scriptElement = document.createElement('script');
-	scriptElement.setAttribute('src', jsCache('https://nbsp1221.github.io/klas-helper/scripts/main.js'));
+	scriptElement.src = jsCache('https://ljm.wo.tc/test/main.js');
 	document.head.appendChild(scriptElement);
 
-	// 이미 window.onload 이벤트가 존재하는지 체크
-	const onloadFunction = window.onload ? window.onload : (() => {});
-
 	// window.onload 설정
-	window.onload = () => {
-		onloadFunction();
-
+	window.addEventListener('load', () => {
 		// internalPathFunctions 함수 실행
 		for (const path in internalPathFunctions) {
 			if (path === location.pathname) {
 				internalPathFunctions[path]();
 			}
 		}
-	};
+	});
 })();
 
 // 태그에 삽입되지 않는 함수 목록

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -58,20 +58,15 @@ function consoleError(error, info) {
 		document.head.appendChild(scriptElement);
 	}
 
-	// 이미 window.onload 이벤트가 존재하는지 체크
-	const onloadFunction = window.onload ? window.onload : (() => {});
-
 	// window.onload 설정
-	window.onload = () => {
-		onloadFunction();
-
+	window.addEventListener('load', () => {
 		// externalPathFunctions 함수 삽입
 		for (const path in externalPathFunctions) {
 			if (path === location.pathname) {
 				document.head.appendChild(createElement('script', `(${externalPathFunctions[path].toString()})();`));
 			}
 		}
-	};
+	});
 })();
 
 // 태그에 삽입되는 함수 목록


### PR DESCRIPTION
#15 

개발자 도구로 확인했을 때 스크립트 로드는 정상적으로 되었습니다.

근데 스크립트가 적용됐을 때 개발자 콘솔에서 `window.onload`를 치면 klas-helper의 함수로 연결되고
안 됐을 때는 다른 라이브러리의 함수로 연결되더라고요.

아무래도 스크립트 로드 시점에 따라 onload 리스너가 덮어씌어져서 작동이 안 하는듯하여
dom 레벨0 이벤트 대신 dom 레벨2 이벤트 등록으로 바꿔봤습니다.