### PR TITLE
[UPDATE] ADD TEAM PROJECT STATUS FUNCTION

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "광운대학교 KLAS 사이트에 편리한 기능을 추가할 수 있는 유저 스크립트",
   "main": "src/main.js",
   "scripts": {
-    "build": "cross-env NODE_ENV=production webpack --config config/webpack.config.ts --progress"
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --config config/webpack.config.ts --progress",
+    "build": "cross-env NODE_ENV=production webpack --config config/webpack.config.ts --progress",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "광운대학교 KLAS 사이트에 편리한 기능을 추가할 수 있는 유저 스크립트",
   "main": "src/main.js",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development webpack-dev-server --config config/webpack.config.ts --progress",
-    "build": "cross-env NODE_ENV=production webpack --config config/webpack.config.ts --progress",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "build": "cross-env NODE_ENV=production webpack --config config/webpack.config.ts --progress"
   },
   "repository": {
     "type": "git",

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -78,15 +78,17 @@ export default () => {
         </div>
         <table id="yes-deadline" style="width: 100%">
           <colgroup>
-            <col width="30%">
-            <col width="35%">
-            <col width="35%">
+            <col width="21%">
+            <col width="25%">
+            <col width="25%">
+            <col width="25%">
           </colgroup>
           <thead>
             <tr style="border-bottom: 1px solid #dce3eb; font-weight: bold; height: 30px">
               <td></td>
               <td>온라인 강의</td>
               <td>과제</td>
+              <td>팀 프로젝트</td>
             </tr>
           </thead>
           <tbody></tbody>
@@ -118,6 +120,11 @@ export default () => {
             remainingTime: Infinity,
             remainingCount: 0,
             totalCount: 0
+          },
+          teamProject: {
+            remainingTime: Infinity,
+            remainingCount: 0,
+            totalCount: 0
           }
         };
 
@@ -130,6 +137,13 @@ export default () => {
 
         // 과제를 가져올 주소 설정
         promises.push(axios.post('/std/lis/evltn/TaskStdList.do', {
+          selectSubj: subject.subj,
+          selectYearhakgi: subject.yearhakgi,
+          selectChangeYn: 'Y'
+        }));
+
+        // 팀 프로젝트를 가져올 주소 설정
+        promises.push(axios.post('/std/lis/evltn/PrjctStdPage.do', {
           selectSubj: subject.subj,
           selectYearhakgi: subject.yearhakgi,
           selectChangeYn: 'Y'
@@ -165,8 +179,13 @@ export default () => {
         }
       };
 
-      // 과제 파싱 함수
-      const parseHomework = (subjectCode, responseData) => {
+      /**
+       * 과제 파싱 함수
+       * @param {String} subjectCode
+       * @param {Object} responseData
+       * @param {String} homeworkType  HW(Personal Homework), TP(Team Project)
+       */
+      const parseHomework = (subjectCode, responseData, homeworkType='HW') => {
         const nowDate = new Date();
 
         for (const homework of responseData) {
@@ -191,15 +210,28 @@ export default () => {
             }
           }
 
-          if (deadline[subjectCode].homework.remainingTime > hourGap) {
-            deadline[subjectCode].homework.remainingTime = hourGap;
-            deadline[subjectCode].homework.remainingCount = 1;
-          }
-          else if (deadline[subjectCode].homework.remainingTime === hourGap) {
-            deadline[subjectCode].homework.remainingCount++;
-          }
+          if (homeworkType === 'HW') {
+            if (deadline[subjectCode].homework.remainingTime > hourGap) {
+              deadline[subjectCode].homework.remainingTime = hourGap;
+              deadline[subjectCode].homework.remainingCount = 1;
+            }
+            else if (deadline[subjectCode].homework.remainingTime === hourGap) {
+              deadline[subjectCode].homework.remainingCount++;
+            }
 
-          deadline[subjectCode].homework.totalCount++;
+            deadline[subjectCode].homework.totalCount++;
+          }
+          else if (homeworkType === 'TP') {
+            if (deadline[subjectCode].teamProject.remainingTime > hourGap) {
+              deadline[subjectCode].teamProject.remainingTime = hourGap;
+              deadline[subjectCode].teamProject.remainingCount = 1;
+            }
+            else if (deadline[subjectCode].teamProject.remainingTime === hourGap) {
+              deadline[subjectCode].teamProject.remainingCount++;
+            }
+
+            deadline[subjectCode].teamProject.totalCount++;
+          }
           isExistDeadline = true;
         }
       };
@@ -215,7 +247,11 @@ export default () => {
               break;
 
             case '/std/lis/evltn/TaskStdList.do':
-              parseHomework(subjectCode, response.data);
+              parseHomework(subjectCode, response.data, 'HW');
+              break;
+
+            case '/std/lis/evltn/PrjctStdPage.do':
+              parseHomework(subjectCode, response.data, 'TP');
               break;
           }
         }
@@ -277,6 +313,11 @@ export default () => {
             <td>
               <span style="cursor: pointer" onclick="appModule.goLctrumBoard('/std/lis/evltn/TaskStdPage.do', '${cur.yearSemester}', '${cur.subjectCode}')">
                 ${createContent('과제', cur.homework)}
+              <span>
+            </td>
+            <td>
+              <span style="cursor: pointer" onclick="appModule.goLctrumBoard('/std/lis/evltn/PrjctStdPage.do', '${cur.yearSemester}', '${cur.subjectCode}')">
+                ${createContent('팀 프로젝트', cur.teamProject)}
               <span>
             </td>
           </tr>

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -143,7 +143,7 @@ export default () => {
         }));
 
         // 팀 프로젝트를 가져올 주소 설정
-        promises.push(axios.post('/std/lis/evltn/PrjctStdPage.do', {
+        promises.push(axios.post('/std/lis/evltn/PrjctStdList.do', {
           selectSubj: subject.subj,
           selectYearhakgi: subject.yearhakgi,
           selectChangeYn: 'Y'
@@ -250,7 +250,7 @@ export default () => {
               parseHomework(subjectCode, response.data, 'HW');
               break;
 
-            case '/std/lis/evltn/PrjctStdPage.do':
+            case '/std/lis/evltn/PrjctStdList.do':
               parseHomework(subjectCode, response.data, 'TP');
               break;
           }


### PR DESCRIPTION
### What was wrong?

* Can't checks user team project homework or contents in any function.
* Related to Issue #43.

### How was it fixed?
This PR shows the user team project homework status to the main page dashboard.
The implementation considers sending an optional homeworkType parameter to distinguish homework type between personal and team project. (with homeworkType = 'HW' as default). 
This source code annotation follows JSdoc annotation style.

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Enhancement

### To-Do
- [x] Clean up commit history

### Demo
![image](https://user-images.githubusercontent.com/11774273/92321247-709d3180-f063-11ea-8ea6-40a2a8df1e69.png)


#### Cute Animal Picture
![IMG_2424](https://user-images.githubusercontent.com/11774273/92321300-c1ad2580-f063-11ea-8021-180a6fe60943.jpg)

