### PR TITLE
[UPDATE] ADD DEVELOPMENT SETUP

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "광운대학교 KLAS 사이트에 편리한 기능을 추가할 수 있는 유저 스크립트",
   "main": "src/main.js",
   "scripts": {
-    "build": "cross-env NODE_ENV=production webpack --config config/webpack.config.ts --progress"
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --config config/webpack.config.ts --progress",
+    "build": "cross-env NODE_ENV=production webpack --config config/webpack.config.ts --progress",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What was wrong?

* Can't find yarn scripts for lint and webpack development serve tools. 

### How was it fixed?
`yarn dev` : Development mode to serve localhost:8080
See my example(`scriptElement.src = jsCache('http://localhost:8080/dist/main.js');`) for tempermonkey with development mode.
`yarn lint` : check your linting is correctly.
`yarn lint:fix` : fix your linting correctly.

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Enhancement

### To-Do
- [x] Clean up commit history

