### PR TITLE
어학성적 수치화 #25

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,7 @@ import handleEvaluation from './evaluation';
 import handleOnlineLecture from './online-lecture';
 import handleTakeLecture from './take-lecture';
 import handleLenturePlan from './lecture-plan-std';
+import handleCalculateToeic from './score-toeic';
 
 export default {
   '/std/cmn/frame/Frame.do': handleHome,
@@ -19,5 +20,6 @@ export default {
   '/std/cps/inqire/LctreEvlViewStdPage.do': handleEvaluation,
   '/std/lis/evltn/OnlineCntntsStdPage.do': handleOnlineLecture,
   '/spv/lis/lctre/viewer/LctreCntntsViewSpvPage.do': handleTakeLecture,
-  '/std/cps/atnlc/popup/LectrePlanStdNumPopup.do': handleLenturePlan
+  '/std/cps/atnlc/popup/LectrePlanStdNumPopup.do': handleLenturePlan,
+  '/std/cps/inqire/ToeicStdPage.do': handleCalculateToeic
 };

--- a/src/routes/score-toeic.js
+++ b/src/routes/score-toeic.js
@@ -1,0 +1,133 @@
+/**
+ * 페이지 이름: 어학 성적 조회
+ * 페이지 주소: https://klas.kw.ac.kr/std/cps/inqire/ToeicStdPage.do
+ */
+
+import {
+  addListenerByTimer
+} from '../utils/dom';
+import {
+  calculateGPA
+} from '../utils/score';
+
+const handleCalculateToeic = () => {
+  const toeicData = [];
+  const topelData = [];
+  const topikData = [];
+  const toeicSpeakingData = [];
+  const opicData = [];
+  const ieltsData = [];
+  const tepsData = [];
+  const languageData = [
+    { title: "TOEIC", borderColor:'#EB373D', data: toeicData },
+    { title: "TOPEL", borderColor:'#22F0A9', data: topelData },
+    { title: "TOPIK", borderColor:'#117FFF', data: topikData },
+    { title: "TOEIC Speaking", borderColor:'#813BEB', data: toeicSpeakingData },
+    { title: "OPIC", borderColor:'#FF2E92', data: opicData },
+    { title: "IELTS", borderColor:'#37F05C', data: ieltsData },
+    { title: "TEPS", borderColor:'#FF9864', data: tepsData }
+  ];
+  const scoreDatas = appModule.$data.list;
+  const chartSettings = {
+    borderWidth: 1,
+    fill: false,
+    lineTension: 0,
+    pointBackgroundColor: 'white',
+    pointRadius: 5
+  }
+
+  // 평점 계산을 위한 데이터 생성
+  for (let i = scoreDatas.length - 1; i >= 0; i--) {
+    const scoreData = scoreDatas[i];
+    if (scoreData.score1 && scoreData.score1 !== "-") {
+      toeicData.push({
+        testDate: scoreData.testDate,
+        score: scoreData.score1,
+      })
+    }
+    if (scoreData.score2 && scoreData.score2 !== "-") {
+      toeicData.push({
+        testDate: scoreData.testDate,
+        score: scoreData.score2,
+      })
+    }
+    if (scoreData.score3 && scoreData.score3 !== "-") {
+      topelData.push({
+        testDate: scoreData.testDate,
+        score: scoreData.score3,
+      })
+    }
+    if (scoreData.score4 && scoreData.score4 !== "-") {
+      toeicSpeakingData.push({
+        testDate: scoreData.testDate,
+        score: scoreData.score4,
+      })
+    }
+    if (scoreData.score5 && scoreData.score5 !== "-") {
+      opicData.push({
+        testDate: scoreData.testDate,
+        score: scoreData.score5,
+      })
+    }
+    if (scoreData.score6 && scoreData.score6 !== "-") {
+      ieltsData.push({
+        testDate: scoreData.testDate,
+        score: scoreData.score6,
+      })
+    }
+    if (scoreData.score7 && scoreData.score7 !== "-") {
+      ieltsData.push({
+        testDate: scoreData.testDate,
+        score: scoreData.score7,
+      })
+    }
+    if (scoreData.scoreD && scoreData.scoreD !== "-") {
+      topikData.push({
+        testDate: scoreData.testDate,
+        score: scoreData.scoreD,
+      })
+    }
+  }
+  
+
+  // 차트 렌더링
+  for (let i = languageData.length - 1; i >= 0; i--) {
+    const languageItem = languageData[i];
+    if (languageItem.data.length < 2) {
+      continue;
+    }
+    $('.AType').after(`
+      <div style="margin-bottom: 25px">
+        <canvas id="score-chart-${languageItem.title}"></canvas>
+      </div>
+    `);
+
+    const ctx = document.getElementById(`score-chart-${languageItem.title}`);
+    ctx.height = 80;
+
+    new Chart(ctx, {
+      type: "line",
+      data: {
+        labels: languageItem.data.map(semester => semester.testDate),
+        datasets: [{
+          label: languageItem.title,
+          data: languageItem.data.map(semester => semester.score),
+          borderColor: languageItem.borderColor,
+          ...chartSettings
+        }
+      ]
+      },
+      options: {
+        responsive: true,
+        interaction: {
+          mode: 'index',
+          intersect: false,
+        },
+      }
+    });
+  }
+};
+
+export default () => {
+  addListenerByTimer(() => appModule?.$data.list.length > 0, handleCalculateToeic);
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25397908/138546531-89b3c069-fe99-48d5-a88b-961986fc4e34.png)


각종 어학정보들을 적당히 파싱해서, 데이터가 2개 이상 있는 경우 그래프를 그리게끔 했습니다.
`광운토익`하고 `정기토익`은 동일한 토익으로 간주해서 그래프 그렸습니다.

사실 하나의 그래프에 모든 데이터들 다 그릴려고 했는데,
수치 기준이 다 다르고, 날짜도 다 다른날에 찍히기 때문에
그냥 각각의 어학정보에 대해서 하나하나 그래프를 그리게 했습니다.

이와는 별개로 주어진 표 정보 자체가 약간 하드코딩된 감이 있어서 저도 약간 무식하게 코딩했는데
더 괜찮은 방법있으면 리뷰 부탁드리겠습니당