### PR TITLE
🚚 Separate dist files to another repo

### DIFF
--- a/dist/klas-helper.user.js
+++ b/dist/klas-helper.user.js
@@ -28,7 +28,7 @@ function jsCache(filePath) {
 	// 메인 파일 삽입
 	// 업데이트 시 즉각적으로 업데이트를 반영하기 위해 이러한 방식을 사용함
 	const scriptElement = document.createElement('script');
-	scriptElement.src = jsCache('https://klas-helper.github.io/klas-helper/dist/main.js');
+	scriptElement.src = jsCache('https://klas-helper.github.io/distribution/main.js');
 	document.head.appendChild(scriptElement);
 
 	// window.onload 설정

--- a/src/klas-helper.user.js
+++ b/src/klas-helper.user.js
@@ -4,7 +4,7 @@ import {
 } from './utils/dom';
 
 const mainURL = isEnvProduction
-  ? 'https://nbsp1221.github.io/klas-helper/dist/main.js'
+  ? 'https://klas-helper.github.io/distribution/main.js'
   : 'http://localhost:8080/main.js';
 
 // 메인 파일 삽입


### PR DESCRIPTION
프로젝트 구조에 대한 변경이 발생했을 때를 대비하여 배포 파일(`main.js`)을 [다른 레포](https://github.com/klas-helper/distribution)로 분리했습니다.

확장 플러그인에서도 기존 주소를 사용하고 있다면 새로운 주소로 변경 부탁드리겠습니다!